### PR TITLE
Add the man pages to the website

### DIFF
--- a/docs/_static/flatpak-docs.html
+++ b/docs/_static/flatpak-docs.html
@@ -1,0 +1,2073 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>Flatpak Command Reference</title><link rel="stylesheet" type="text/css" href="docbook.css" /><meta name="generator" content="DocBook XSL Stylesheets Vsnapshot" /></head><body><div class="reference"><div class="titlepage"><div><div><h1 class="title"><a id="idm140537887527968"></a>Flatpak Command Reference</h1></div><div><p class="releaseinfo">Version 0.9.2</p></div></div><hr /></div><div class="partintro"><div></div><p>
+        Flatpak comes with a rich commandline interface.
+      </p><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak-install">flatpak install</a></span><span class="refpurpose"> — Install an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-update">flatpak update</a></span><span class="refpurpose"> — Update an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-uninstall">flatpak uninstall</a></span><span class="refpurpose"> — Uninstall an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-list">flatpak list</a></span><span class="refpurpose"> — List installed applications and/or runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-info">flatpak info</a></span><span class="refpurpose"> — Show information about installed application and/or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-run">flatpak run</a></span><span class="refpurpose"> — Run an application or open a shell in a runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-override">flatpak override</a></span><span class="refpurpose"> — Override application requirements</span></dt><dt><span class="refentrytitle"><a href="#flatpak-enter">flatpak enter</a></span><span class="refpurpose"> — Enter an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-export">flatpak document-export</a></span><span class="refpurpose"> — Export a file to a sandboxed application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-unexport">flatpak document-unexport</a></span><span class="refpurpose"> — Stop exporting a file</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-info">flatpak document-info</a></span><span class="refpurpose"> — Show information about exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-list">flatpak document-list</a></span><span class="refpurpose"> — List exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remotes">flatpak remotes</a></span><span class="refpurpose"> — List remote repositories</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-add">flatpak remote-add</a></span><span class="refpurpose"> — Add a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-modify">flatpak remote-modify</a></span><span class="refpurpose"> — Modify a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-delete">flatpak remote-delete</a></span><span class="refpurpose"> — Delete a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-ls">flatpak remote-ls</a></span><span class="refpurpose"> — Show available runtimes and applications</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-init">flatpak build-init</a></span><span class="refpurpose"> — Initialize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build">flatpak build</a></span><span class="refpurpose"> — Build in a directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-finish">flatpak build-finish</a></span><span class="refpurpose"> — Finalize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-export</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-bundle">flatpak build-bundle</a></span><span class="refpurpose"> — Create a single-file bundle from a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-import-bundle">flatpak build-import-bundle</a></span><span class="refpurpose"> — Import a file bundle into a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-update-repo">flatpak build-update-repo</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-sign</a></span><span class="refpurpose"> — Sign an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-builder">flatpak-builder</a></span><span class="refpurpose"> — Help build application dependencies</span></dt><dt><span class="refentrytitle"><a href="#flatpak-metadata">flatpak metadata</a></span><span class="refpurpose"> — Information about an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakrepo">flatpakrepo</a></span><span class="refpurpose"> — Reference to a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakref">flatpakref</a></span><span class="refpurpose"> — Reference to a remote for an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-make-current">flatpak make-current</a></span><span class="refpurpose"> — Make a specific version of an app current</span></dt></dl></div></div><div class="refentry"><a id="flatpak-install"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-install — Install an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><p>Install from a configured remote:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...]  REMOTE-NAME   REF... </p></div><p>Install from a .flatpakref file:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...] [--from]  LOCATION </p></div><p>Install from a .flatpak bundle:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...] [--bundle]  FILENAME </p></div></div><div class="refsect1"><a id="idm140537880321072"></a><h2>Description</h2><p>
+          Installs an application or runtime. The primary way to
+          install is to specify a [REMOTE]
+          name as the source and one ore more  [REF]s to specify the
+          application or runtime to install.
+        </p><p>
+            Each  REF  argument is a full or partial indentifier in the
+            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
+            except ID are optional and can be left out, including the slashes,
+            so most of the time you need only specify ID. Any part left out will be matched
+            against what is in the remote, and if there are multiple matches an error message
+            will list the alternatives.
+        </p><p>
+            By default this looks for both apps and runtime with the given  REF  in
+            the specified   REMOTE , but you can limit this by using the --app or
+            --runtime option, or by supplying the initial element in the REF.
+        </p><p>
+            The alternative form of the command ([--from] or
+             [--bundle] allows you to
+            install directly from a source such as a .flatpak
+            single-file bundle, a .flatpakref app description. The options are optional if the first
+            argument have the right extension.
+        </p><p>
+            Note that flatpak allows one to have multiple branches of an application and runtimes
+            installed and used at the same time. However, only version of an application one can be current,
+            meaning its exported files (for instance desktop files and icons) are
+            visible to the host. The last installed version is made current by
+            default, but you can manually change with make-current.
+        </p><p>
+            Unless overridden with the --user or the --installation option, this command installs
+            the application or runtime in the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537880309184"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--bundle</code></span></dt><dd><p>
+                  Assume LOCATION is a .flatpak single-bundle file.
+                  This is optional if the arguments ends with .flatpak.
+                </p></dd><dt><span class="term"><code class="option">--from</code></span></dt><dd><p>
+                  Assume LOCATION is a .flatpakref file containing the details of the app to be installed.
+                  This is optional if the arguments ends with .flatpakref.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Install the application or runtime in a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Install the application or runtime in the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Install the application or runtime in a system-wide installation
+                    specified by  NAME  among those defined in
+                    <code class="filename">/etc/flatpak/installations.d/</code>. Using
+                      --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The default architecture to install for, if not given explicitly in the  REF .
+                </p></dd><dt><span class="term"><code class="option">--subpath=PATH</code></span></dt><dd><p>
+                  Install only a subpath of the ref. This is mainly used to install a subset of locales.
+                  This can be added multiple times to install multiple subpaths.,
+                </p></dd><dt><span class="term"><code class="option">--gpg-file=FILE</code></span></dt><dd><p>
+                  Check bundle signatures with GPG key from FILE (- for stdin).
+                </p></dd><dt><span class="term"><code class="option">--no-deploy</code></span></dt><dd><p>
+                    Download the latest version, but don't deploy it.
+                </p></dd><dt><span class="term"><code class="option">--no-pull</code></span></dt><dd><p>
+                    Don't download the latest version, deploy whatever is locally available.
+                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
+                    Don't download related extensions, such as the locale data.
+                </p></dd><dt><span class="term"><code class="option">--no-deps</code></span></dt><dd><p>
+                    Don't verify runtime dependencies when installing.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Assume that all  REF s are apps if not explicitly specified.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Assume that all  REF s are runtimes if not explicitly specified.
+                </p></dd><dt><span class="term"><code class="option">-y</code>, </span><span class="term"><code class="option">--assumeyes</code></span></dt><dd><p>
+                    Automatically answer yes to all questions (or pick the most prioritized answer). This is useful for automation.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877870416"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak install gnome org.gnome.gedit2</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak --installation=default install gnome org.gnome.gedit2</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak --user install gnome org.gnome.gedit//3.22</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak --user install https://sdk.gnome.org/gedit.flatpakref</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537877865616"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-bundle</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-flatpakref</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-update"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-update — Update an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak update</code>  [OPTION...] [REF...]</p></div></div><div class="refsect1"><a id="idm140537880837856"></a><h2>Description</h2><p>
+            Updates applications and runtimes.  REF  is a reference to the
+            application or runtime to install. If no   REF  is given, everything
+            is updated.
+        </p><p>
+            Each  REF  arguments is a full or partial indentifier in the
+            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
+            except ID are optional and can be left out, including the slashes,
+            so most of the time you need only specify ID. Any part left out will be matched
+            against what is installed, and if there are multiple matches an error message
+            will list the alternatives.
+        </p><p>
+            By default this looks for both apps and runtime with the given  REF  in
+            the specified   REMOTE , but you can limit this by using the --app or
+            --runtime option, or by supplying the initial element in the REF.
+        </p><p>
+            Normally, this command updates the application to the tip
+            of its branch. But it is possible to check out another commit,
+            with the --commit option.
+        </p><p>
+            Note that updating a runtime is different from installing
+            a different branch, and runtime updates are expected to keep
+            strict compatibility. If an application update does cause
+            a problem, it is possible to go back to the previous
+            version, with the --commit option.
+        </p><p>
+            Unless overridden with the --user or the --installation option, this command updates
+            the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537881039200"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Update a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Update the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to update for.
+                </p></dd><dt><span class="term"><code class="option">--subpath=PATH</code></span></dt><dd><p>
+                  Install only a subpath of the ref. This is mainly used to install a subset of locales.
+                  This can be added multiple times to install multiple subpaths.
+                  If this is not specified the subpaths specified at install time are reused.
+                </p></dd><dt><span class="term"><code class="option">--commit=COMMIT</code></span></dt><dd><p>
+                    Update to this commit, instead of the tip of the branch.
+                </p></dd><dt><span class="term"><code class="option">--no-deploy</code></span></dt><dd><p>
+                    Download the latest version, but don't deploy it.
+                </p></dd><dt><span class="term"><code class="option">--no-pull</code></span></dt><dd><p>
+                    Don't download the latest version, deploy it whatever is locally available.
+                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
+                    Don't download related extensions, such as the locale data.
+                </p></dd><dt><span class="term"><code class="option">--no-deps</code></span></dt><dd><p>
+                    Don't update or install runtime dependencies when installing.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Only look for an app with the given name.
+                </p></dd><dt><span class="term"><code class="option">--appstream</code></span></dt><dd><p>
+                    Update appstream for the remote.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Only look for an runtime with the given name.
+                </p></dd><dt><span class="term"><code class="option">-y</code>, </span><span class="term"><code class="option">--assumeyes</code></span></dt><dd><p>
+                    Automatically answer yes to all questions (or pick the most prioritized answer). This is useful for automation.
+                </p></dd><dt><span class="term"><code class="option">--force-remove</code></span></dt><dd><p>
+                    Remove old files even if they're in use by a running application.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537881715184"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user update org.gnome.GEdit</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537877860144"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-uninstall"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-uninstall — Uninstall an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak uninstall</code>  [OPTION...] [REF...]</p></div></div><div class="refsect1"><a id="idm140537881468736"></a><h2>Description</h2><p>
+            Uninstalls an application or runtime.  REF  is a reference to the
+            application or runtime to install. If no   REF  is given, everything
+            is updated.
+        </p><p>
+            Each  REF  arguments is a full or partial indentifier in the
+            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
+            except ID are optional and can be left out, including the slashes,
+            so most of the time you need only specify ID. Any part left out will be matched
+            against what is installed, and if there are multiple matches an error message
+            will list the alternatives.
+        </p><p>
+            By default this looks for both installed apps and runtime
+            with the given  NAME , but you can
+            limit this by using the --app or --runtime option.
+        </p><p>
+            Normally, this command removes the ref for this application/runtime from the
+            local OSTree repository and purges and objects that are no longer
+            needed to free up disk space. If the same application is later
+            reinstalled, the objects will be pulled from the remote repository
+            again. The --keep-ref option can be used to prevent this.
+        </p><p>
+            If all branches of the application/runtime are removed, this command
+            also purges the data directory for the application.
+        </p><p>
+            Unless overridden with the --user or the --installation option, this command updates
+            the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537878905056"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--keep-ref</code></span></dt><dd><p>
+                    Keep the ref for the application and the objects belonging to it
+                    in the local repository.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Updates a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Updates the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to uninstall, instead of the architecture of
+                    the host system.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Only look for an app with the given name.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Only look for an runtime with the given name.
+                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
+                    Don't uninstall related extensions, such as the locale data.
+                </p></dd><dt><span class="term"><code class="option">--force-remove</code></span></dt><dd><p>
+                    Remove files even if they're in use by a running application.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537879218208"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user uninstall org.gnome.GEdit</strong></span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-list"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-list — List installed applications and/or runtimes</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak list</code>  [OPTION...]</p></div></div><div class="refsect1"><a id="idm140537878217136"></a><h2>Description</h2><p>
+            Lists the names of the installed applications and/or runtime.
+        </p><p>
+            By default, both per-user and system-wide installations
+            are shown. Use the --user, --installation or --system
+            options to change this.
+        </p><p>
+            By default this lists both installed apps and runtime, but you can
+            change this by using the --app or --runtime option.
+        </p></div><div class="refsect1"><a id="idm140537879732624"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    List per-user installations.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    List the default system-wide installations.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    List a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    List installations for this architecture.
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
+                    Show origin, sizes and other extra information.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    List applications.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    List runtimes.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878145680"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user list</strong></span>
+        </p><pre class="programlisting">
+org.gnome.Builder
+org.freedesktop.glxgears
+org.gnome.MyApp
+org.gnome.GEdit
+</pre></div><div class="refsect1"><a id="idm140537878066048"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-info — Show information about installed application and/or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak info</code>  [OPTION...]  NAME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm140537879064288"></a><h2>Description</h2><p>
+            Show info about and installed application and/or runtime.
+        </p><p>
+            By default, both per-user and system-wide installations
+            are queried. Use the --user, --system or --installation
+            options to change this.
+        </p><p>
+            By default this queries the installed apps and runtimes, but you can
+            limit this by using the --app or --runtime option.
+        </p></div><div class="refsect1"><a id="idm140537878611536"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Query per-user installations.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Query the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Query a system-wide installation by  NAME  among
+                    those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Query for applications.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Query for runtimes.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Query for this architecture.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--show-ref</code></span></dt><dd><p>
+                    Show the installed ref.
+                </p></dd><dt><span class="term"><code class="option">-o</code>, </span><span class="term"><code class="option">--show-origin</code></span></dt><dd><p>
+                    Show the remote the ref is installed from.
+                </p></dd><dt><span class="term"><code class="option">-c</code>, </span><span class="term"><code class="option">--show-commit</code></span></dt><dd><p>
+                    Show the installed commit id.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537882404208"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak info org.gnome.Builder//master</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537881852720"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-run"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-run — Run an application or open a shell in a runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak run</code>  [OPTION...]  REF  [ARG...]</p></div></div><div class="refsect1"><a id="idm140537877966448"></a><h2>Description</h2><p>
+            If  REF  names an installed application,
+            flatpak runs the application in a sandboxed environment. Extra
+            arguments are passed on to the application.
+        </p><p>
+            If  REF  names a runtime, a shell is opened in the
+            runtime. This is useful for development and testing.
+        </p><p>
+            flatpak creates a sandboxed environment for the application to run in
+            by mounting the right runtime at <code class="filename">/usr</code> and a writable
+            directory at <code class="filename">/var</code>, whose content is preserved between
+            application runs. The application itself is mounted at <code class="filename">/app</code>.
+        </p><p>
+            The details of the sandboxed environment are controlled by the application
+            metadata and various options like --share and --socket that are passed to the run
+            command: Access is allowed if it was requested either in the application
+            metadata file or with an option and the user hasn't overridden it.
+        </p></div><div class="refsect1"><a id="idm140537878161232"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to install for.
+                </p></dd><dt><span class="term"><code class="option">--command=COMMAND</code></span></dt><dd><p>
+                    The command to run instead of the one listed in the application metadata.
+                </p></dd><dt><span class="term"><code class="option">--branch=BRANCH</code></span></dt><dd><p>
+                    The branch to use.
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--devel</code></span></dt><dd><p>
+                    Use the devel runtime that is specified in the application metadata instead of the regular runtime, and use a seccomp profile that is less likely to break development tools.
+                </p></dd><dt><span class="term"><code class="option">--runtime=RUNTIME</code></span></dt><dd><p>
+                  Use this runtime instead of the one that is specified in the application metadata.
+                  This is a full tuple, like for example  org.freedesktop.Sdk/x86_64/1.2 , but
+                  partial tuples are allowed. Any empty or missing parts are filled in with the corresponding
+                  values specified by the app.
+                </p></dd><dt><span class="term"><code class="option">--runtime-version=VERSION</code></span></dt><dd><p>
+                  Use this version of the runtime instead of the one that is specified in the application metadata.
+                  This overrides any version specified with the --runtime option.
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This overrides to
+                    the Context section from the application metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This overrides to
+                    the Context section from the application metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This overrides to the Context section from the application metadata.
+                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    xdg-run, xdg-config, xdg-cache, xdg-data,
+                    an absolute path, or a homedir-relative path like ~/dir or paths
+                    relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--log-session-bus</code></span></dt><dd><p>
+                    Log session bus traffic. This can be useful to see what access you need to allow in
+                    your D-Bus policy.
+                </p></dd><dt><span class="term"><code class="option">--log-system-bus</code></span></dt><dd><p>
+                    Log system bus traffic. This can be useful to see what access you need to allow in
+                    your D-Bus policy.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537882327744"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak run org.gnome.GEdit</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak run --devel --command=bash org.gnome.Builder</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak run --command=bash org.gnome.Sdk</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537882323392"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-override</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-enter</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-override"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-override — Override application requirements</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak override</code>  [OPTION...]  APP </p></div></div><div class="refsect1"><a id="idm140537879790096"></a><h2>Description</h2><p>
+            Overrides the application specified runtime requirements. This can be used
+            to grant a sandboxed application more or less resources than it requested.
+        </p><p>
+            By default the application gets access to the resources it
+            requested when it is started. But the user can override it
+            on a particular instance by specifying extra arguments to
+            flatpak run, or every time by using flatpak override.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537878065600"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Update a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Update the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                 </p><p>
+                    The <code class="code">devel</code> feature allows the application to
+                    access certain syscalls such as <code class="code">ptrace()</code>, and
+                <code class="code">perf_event_open()</code>.
+                </p><p>
+                    The <code class="code">multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code class="code">x86_64</code>
+                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
+                    well.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This overrides to the Context section from the application metadata.
+                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-config, xdg-cache, xdg-data,
+                    an absolute path, or a homedir-relative path like ~/dir or paths
+                    relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877842272"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak override --nosocket=wayland org.gnome.GEdit</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak override --filesystem=home org.mozilla.Firefox</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537877839104"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-enter"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-enter — Enter an application</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak enter</code>  [OPTION...]  MONITORPID   COMMAND  [ARG...]</p></div></div><div class="refsect1"><a id="idm140537880056208"></a><h2>Description</h2><p>
+            Enter a running sandbox.
+             SANDBOXEDPID  must be the pid of a process running in a flatpak sandbox.
+              COMMAND  is the command to run in the sandbox.
+            Extra arguments are passed on to the command.
+        </p><p>
+            This creates a new process within the running sandbox, with the same environment. This is useful
+            when you want to debug a problem with a running application.
+        </p><p>
+            This command requires extra privileges, so must be run as root or via e.g. sudo.
+        </p></div><div class="refsect1"><a id="idm140537881185696"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537880793632"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak enter 15345 sh</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537878065328"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-export — Export a file to a sandboxed application</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-export</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm140537881463792"></a><h2>Description</h2><p>
+            Creates a document id for a local file that can be exposed to
+            sandboxed applications, allowing them access to files that they
+            would not otherwise see. The exported files are exposed in a
+            fuse filesystem at /run/user/$UID/doc/.
+        </p><p>
+            This command also lets you modify the per-application
+            permissions of the documents, granting or revoking access
+            to the file on a per-application basis.
+        </p></div><div class="refsect1"><a id="idm140537878178224"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-u</code>, </span><span class="term"><code class="option">--unique</code></span></dt><dd><p> Don't reuse an existing document id
+                for the file.  This makes it safe to later remove the
+                document when you're finished with it.
+                </p></dd><dt><span class="term"><code class="option">-t</code>, </span><span class="term"><code class="option">--transient</code></span></dt><dd><p>
+                  The document will only exist for the length of
+                  the session. This is useful for temporary grants.
+                </p></dd><dt><span class="term"><code class="option">-n</code>, </span><span class="term"><code class="option">--noexist</code></span></dt><dd><p>
+                  Don't require the file to exist already.
+                </p></dd><dt><span class="term"><code class="option">-a</code>, </span><span class="term"><code class="option">--app=APPID</code></span></dt><dd><p>
+                  Grant read access to the specified application. The
+                  --allow and --forbid options can be used to grant
+                  or remove additional privileges.
+                  This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--allow-read</code></span></dt><dd><p>
+                  Grant read access to the applications specified with --app.
+                  This defaults to TRUE.
+                </p></dd><dt><span class="term"><code class="option">--forbid-read</code></span></dt><dd><p>
+                  Revoke read access for the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-w</code>, </span><span class="term"><code class="option">--allow-write</code></span></dt><dd><p>
+                  Grant write access to the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">--forbid-write</code></span></dt><dd><p>
+                  Revoke write access for the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--allow-delete</code></span></dt><dd><p>
+                  Grant the ability to remove the document from the document portal to the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">--forbid-delete</code></span></dt><dd><p>
+                  Revoke the ability to remove the document from the document portal from the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-g</code>, </span><span class="term"><code class="option">--allow-grant-permission</code></span></dt><dd><p>
+                  Grant the ability to grant further permissions to the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">--forbid-grant-permission</code></span></dt><dd><p>
+                  Revoke the ability to grant further permissions for the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537881343632"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak document-export --app=org.gnome.GEdit ~/test.txt</strong></span>
+        </p><pre class="programlisting">
+/run/user/1000/doc/e52f9c6a/test.txt
+</pre></div><div class="refsect1"><a id="idm140537881340864"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-unexport"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-unexport — Stop exporting a file</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-export</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm140537879096960"></a><h2>Description</h2><p>
+            Removes the document id for the file from the
+            document portal. This will make the document unavailable
+            to all sandboxed applications.
+        </p></div><div class="refsect1"><a id="idm140537879686912"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878091616"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-info — Show information about exported files</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-info</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm140537880944208"></a><h2>Description</h2><p>
+            Shows information about an exported file, such as the
+            document id, the fuse path, the original location in the
+            filesystem, and the per-application permissions.
+        </p><p>
+            FILE can either be a file in the fuse filesystem at /run/user/$UID/doc/,
+            or a file anywhere else.
+        </p></div><div class="refsect1"><a id="idm140537878144288"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537882089680"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak document-info ~/Sources/gtk/gail-3.0.pc</strong></span>
+        </p><pre class="programlisting">
+id: dd32c34a
+path: /run/user/1000/doc/dd32c34a/gail-3.0.pc
+origin: /home/mclasen/Sources/gtk/gail-3.0.pc
+permissions:
+        org.gnome.gedit read, write
+</pre></div><div class="refsect1"><a id="idm140537881951312"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-list"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-list — List exported files</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-list</code>  [OPTION...] [APPID]</p></div></div><div class="refsect1"><a id="idm140537882357520"></a><h2>Description</h2><p>
+            Lists exported files, with their document id and the
+            full path to their origin. If an APPID is specified,
+            only the files exported to this app are listed.
+        </p></div><div class="refsect1"><a id="idm140537882256256"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878391600"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remotes"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remotes — List remote repositories</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remotes</code>  [OPTION...]</p></div></div><div class="refsect1"><a id="idm140537878962864"></a><h2>Description</h2><p>
+            Lists the known remote repositories, in priority order.
+        </p><p>
+            By default, both per-user and system-wide installations
+            are shown. Use the --user, --system or --installation
+            options to change this.
+        </p></div><div class="refsect1"><a id="idm140537880914592"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Show the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Show the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Show a system-wide installation by  NAME  among
+                    those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
+                    Show more information each repository in addition to the name.
+                </p></dd><dt><span class="term"><code class="option">--show-disabled</code></span></dt><dd><p>
+                    Show disabled repos.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537879490768"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak remotes --user --show-details</strong></span>
+        </p><pre class="programlisting">
+testrepo	Test Repository	 http://209.132.179.91/repo/ no-gpg-verify
+</pre></div><div class="refsect1"><a id="idm140537879488112"></a><h2>See also</h2><p>
+                <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-add-remote</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-delete-remote</span>(1)</span>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-add"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-add — Add a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><p>Add from a .flatpakrepo file:</p><div class="cmdsynopsis"><p><code class="command">flatpak remote-add</code>  [OPTION...] [--from]  NAME   LOCATION </p></div><p>Manually specify repo uri and options:</p><div class="cmdsynopsis"><p><code class="command">flatpak remote-add</code>  [OPTION...]  NAME   LOCATION </p></div></div><div class="refsect1"><a id="idm140537879137344"></a><h2>Description</h2><p>
+            Adds a remote repository to the flatpak repository
+            configuration.  [NAME] is the name for the new
+            remote, and  [LOCATION] is a url or pathname.  The
+             [LOCATION] is either a flatpak repository, or a
+            .flatpakrepo file which describes a repository. In the
+            former case you may also have to specify extra options,
+            such as the gpg key for the repo.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537881962688"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--from</code></span></dt><dd><p>
+                  Assume the URI is a .flatpakrepo file rather than the repository itself. This is enabled
+                  by default if the extension is .flatpakrepo, so generally you don't need this option.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Modify the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Modify the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Modify a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--no-gpg-verify</code></span></dt><dd><p>
+                    Disable GPG verification for the added remote.
+                </p></dd><dt><span class="term"><code class="option">--prio=PRIO</code></span></dt><dd><p>
+                    Set the priority for the remote. Default is 1, higher is more prioritized. This is
+                    mainly used for graphical installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-enumerate</code></span></dt><dd><p>
+                    Mark the remote as not enumerated. This means the remote will
+                    not be used to list applications, for instance in graphical
+                    installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-use-for-deps</code></span></dt><dd><p>
+                    Mark the remote as not to be used for automatic runtime
+                    dependency resolution.
+                </p></dd><dt><span class="term"><code class="option">--if-not-exists</code></span></dt><dd><p>
+                    Do nothing if the provided remote already exists.
+                </p></dd><dt><span class="term"><code class="option">--disable</code></span></dt><dd><p>
+                    Disable the added remote.
+                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
+                    A title for the remote, e.g. for display in a UI.
+                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
+                    A default branch for the remote, mainly for use in a UI.
+                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
+                     Import gpg keys from the specified keyring file as
+                     trusted for the new remote. If the file is - the
+                     keyring is read from standard input.
+                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
+                    This is a OCI format registry rather than a regular
+                    flatpak repository.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877531008"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak remote-add gnome https://sdk.gnome.org/gnome.flatpakrepo</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak --user remote-add --no-gpg-verify test-repo https://people.gnome.org/~alexl/gnome-sdk/repo/</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537877527728"></a><h2>See also</h2><p>
+                <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-modify-remote</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-delete-remote</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-list-remotes</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-flatpakrepo</span>(1)</span>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-modify"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-modify — Modify a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-modify</code>  [OPTION...]  NAME </p></div></div><div class="refsect1"><a id="idm140537878618368"></a><h2>Description</h2><p>
+            Modifies options for an existing remote repository in the flatpak repository configuration.
+             NAME  is the name for the remote.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537879132032"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Modify the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Modify the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Modify a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--no-gpg-verify</code></span></dt><dd><p>
+                    Disable GPG verification for the added remote.
+                </p></dd><dt><span class="term"><code class="option">--gpg-verify</code></span></dt><dd><p>
+                    Enable GPG verification for the added remote.
+                </p></dd><dt><span class="term"><code class="option">--prio=PRIO</code></span></dt><dd><p>
+                    Set the priority for the remote. Default is 1, higher is more prioritized. This is
+                    mainly used for graphical installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-enumerate</code></span></dt><dd><p>
+                    Mark the remote as not enumerated. This means the remote will
+                    not be used to list applications, for instance in graphical
+                    installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-use-for-deps</code></span></dt><dd><p>
+                    Mark the remote as not to be used for automatic runtime
+                    dependency resolution.
+                </p></dd><dt><span class="term"><code class="option">--disable</code></span></dt><dd><p>
+                    Disable the remote. Disabled remotes will not be automatically updated from.
+                </p></dd><dt><span class="term"><code class="option">--enable</code></span></dt><dd><p>
+                    Enable the remote.
+                </p></dd><dt><span class="term"><code class="option">--enumerate</code></span></dt><dd><p>
+                    Mark the remote as enumerated. This means the remote will
+                    be used to list applications, for instance in graphical
+                    installation tools.
+                </p></dd><dt><span class="term"><code class="option">--use-for-deps</code></span></dt><dd><p>
+                    Mark the remote as to be used for automatic runtime
+                    dependency resolution.
+                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
+                    A title for the remote, e.g. for display in a UI.
+                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
+                    A default branch to for the remote, mainly for use in a UI.
+                </p></dd><dt><span class="term"><code class="option">--url=URL</code></span></dt><dd><p>
+                    Set a new URL.
+                </p></dd><dt><span class="term"><code class="option">--update-metadata</code></span></dt><dd><p>
+                    A default branch to for the remote, mainly for use in a UI.
+                </p><p>
+                    Update the remote's extra metadata from the OSTree repository's summary
+                    file. Only xa.title and xa.default-branch are supported at the moment.
+                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
+                     Import gpg keys from the specified keyring file as
+                     trusted for the new remote. If the file is - the
+                     keyring is read from standard input.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537882210720"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-modify --no-gpg-verify test-repo</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537882208688"></a><h2>See also</h2><p>
+                <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-remote-delete</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-delete"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-delete — Delete a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-delete</code>  [OPTION...]  NAME </p></div></div><div class="refsect1"><a id="idm140537879585424"></a><h2>Description</h2><p>
+            Removes a remote repository from the flatpak repository configuration.
+             NAME  is the name of an existing remote.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537886206352"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Modify the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Modify the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Modify a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--force</code></span></dt><dd><p>
+                    Remove remote even if its in use by installed apps or runtimes.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537881244064"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-delete dried-raisins</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537881242032"></a><h2>See also</h2><p>
+                <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-add-remote</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-modify-remote</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-list-remotes</span>(1)</span>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-ls"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-ls — Show available runtimes and applications</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-ls</code>  [OPTION...]  REMOTE </p></div></div><div class="refsect1"><a id="idm140537879333920"></a><h2>Description</h2><p>
+            Shows runtimes and applications that are available in the
+            remote repository with the name  REMOTE .
+            You can find all configured remote repositories with flatpak remote-list.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            uses the default system-wide configuration.
+        </p></div><div class="refsect1"><a id="idm140537879704496"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Use the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Use the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Use a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
+                    Show arches, branches and commit ids, in addition to the names.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Show only runtimes, omit applications.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Show only applications, omit runtimes.
+                </p></dd><dt><span class="term"><code class="option">--updates</code></span></dt><dd><p>
+                    Show only those which have updates available.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Show only those matching the specied architecture. By default, only
+                    supported architectures are shown. Use --arch=* to show all archtectures.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878465008"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-ls --only-apps testrepo</strong></span>
+        </p><pre class="programlisting">
+org.gnome.Builder
+org.freedesktop.glxgears
+</pre></div><div class="refsect1"><a id="idm140537878462288"></a><h2>See also</h2><p>
+                <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+                <span class="citerefentry"><span class="refentrytitle">flatpak-remote-list</span>(1)</span>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-init"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-init — Initialize a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-init</code>  [OPTION...]  DIRECTORY   APPNAME   SDK   RUNTIME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm140537877575552"></a><h2>Description</h2><p>
+            Initializes a directory for building an application.
+             DIRECTORY  is the name of the directory.
+              APPNAME  is the application id of the app
+            that will be built.
+              SDK  and   RUNTIME 
+            specify the sdk and runtime that the application should be built
+            against and run in.
+        </p><p>
+            The result of this command is that a <code class="filename">metadata</code>
+            file is created inside the given directory. Additionally, empty
+            <code class="filename">files</code> and <code class="filename">var</code> subdirectories
+            are created.
+        </p><p>
+            It is an error to run build-init on a directory that has already
+            been initialized as a build directory.
+        </p></div><div class="refsect1"><a id="idm140537881702736"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to use.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--var=RUNTIME</code></span></dt><dd><p>
+                    Initialize var from the named runtime.
+                </p></dd><dt><span class="term"><code class="option">-w</code>, </span><span class="term"><code class="option">--writable-sdk</code></span></dt><dd><p>
+                    Initialize /usr with a copy of the sdk, which is writable during flatpak build. This can be used
+                    if you need to install build tools in /usr during the build. This is stored in the
+                    <code class="filename">usr</code> subdirectory of the app dir, but will not be part of the final
+                    app.
+                </p></dd><dt><span class="term"><code class="option">--tag=TAG</code></span></dt><dd><p>
+                    Add a tag to the metadata file.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--sdk-extension=EXTENSION</code></span></dt><dd><p>
+                    When using --writable-sdk, in addition to the sdk, also install the specified extension.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--sdk-dir</code></span></dt><dd><p>
+                    Specify a custom subdirectory to use instead of <code class="filename">usr</code> for --writable-sdk.
+                </p></dd><dt><span class="term"><code class="option">--update</code></span></dt><dd><p>
+                    Re-initialize the sdk and var, don't fail if already initialized.
+                </p></dd><dt><span class="term"><code class="option">--base=APP</code></span></dt><dd><p>
+                    Initialize the application with files from another specified application.
+                </p></dd><dt><span class="term"><code class="option">--base-version=VERSION</code></span></dt><dd><p>
+                    Specify the version to use for --base. If not specified, will default to
+                    "master".
+                </p></dd><dt><span class="term"><code class="option">--base-extension=EXTENSION</code></span></dt><dd><p>
+                    When using --base, also install the specified extension from the app.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--type=TYPE</code></span></dt><dd><p>
+                    This can be used to build different types of things. The default
+                    is "app" which is a regular app, but "runtime" creates a runtime
+                    based on an existing runtime, and "extension" creates an extension
+                    for an app or runtime.
+                </p></dd><dt><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878574400"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-init /build/my-app org.gnome.Sdk org.gnome.Platform 3.16</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537878572368"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build — Build in a directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build</code>  [OPTION...]  DIRECTORY  [COMMAND [ARG...]]</p></div></div><div class="refsect1"><a id="idm140537880602464"></a><h2>Description</h2><p>
+            Runs a build command in a directory.  DIRECTORY 
+            must have been initialized with <span class="command"><strong>flatpak build-init</strong></span>.
+        </p><p>
+            The sdk that is specified in the <code class="filename">metadata</code> file
+            in the directory is mounted at <code class="filename">/usr</code> and the
+            <code class="filename">files</code> and <code class="filename">var</code> subdirectories
+            are mounted at <code class="filename">/app</code> and <code class="filename">/var</code>,
+            respectively. They are writable, and their contents are preserved between
+            build commands, to allow accumulating build artifacts there.
+        </p></div><div class="refsect1"><a id="idm140537879319280"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Use the non-devel runtime that is specified in the application metadata instead of the devel runtime.
+                </p></dd><dt><span class="term"><code class="option">--bind-mount=DEST=SOURCE</code></span></dt><dd><p>
+                    Add a custom bind mount in the build namespace. Can be specified multiple times.
+                </p></dd><dt><span class="term"><code class="option">--build-dir=PATH</code></span></dt><dd><p>
+                    Start the build in this directory (default is in the current directory).
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                 </p><p>
+                    The <code class="code">devel</code> feature allows the application to
+                    access certain syscalls such as <code class="code">ptrace()</code>, and
+                <code class="code">perf_event_open()</code>.
+                </p><p>
+                    The <code class="code">multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code class="code">x86_64</code>
+                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
+                    well.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FILESYSTEM[:ro|:create]</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This overrides to the Context section from the application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
+                    path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well-known name NAME on the system bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well-known name NAME on the system bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--sdk-dir=DIR</code></span></dt><dd><p>
+                  Normally if there is a <code class="filename">usr</code> directory in the build dir, this is used
+                  for the runtime files (this can be created by --writable-sdk or --type=runtime arguments
+                  to build-init). If you specify --sdk-dir this directoryname will be used instead.
+                  Use this if you passed --sdk-dir to build-init.
+                </p></dd><dt><span class="term"><code class="option">--metadata=FILE</code></span></dt><dd><p>
+                  Use the specified filename as metadata in the exported app instead of
+                  the default file (called <code class="filename">metadata</code>). This is useful
+                  if you build multiple things from a single build tree (such as both a
+                  platform and a sdk).
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877758096"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build /build/my-app rpmbuild my-app.src.rpm</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537877756064"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-finish"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-finish — Finalize a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-finish</code>  [OPTION...]  DIRECTORY </p></div></div><div class="refsect1"><a id="idm140537877574816"></a><h2>Description</h2><p>
+            Finalizes a build directory, to prepare it for exporting.
+             DIRECTORY  is the name of the directory.
+        </p><p>
+            The result of this command is that desktop files, icons and
+            D-Bus service files from the <code class="filename">files</code> subdirectory
+            are copied to a new <code class="filename">export</code> subdirectory. In the
+            <code class="filename">metadata</code> file, the command key is set in the
+            [Application] group, and the supported keys in the [Environment]
+            group are set according to the options.
+        </p><p>
+            You should review the exported files and the application metadata
+            before creating and distributing an application bundle.
+        </p><p>
+            It is an error to run build-finish on a directory that has not
+            been initialized as a build directory, or has already been finalized.
+        </p></div><div class="refsect1"><a id="idm140537880095648"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--command=COMMAND</code></span></dt><dd><p>
+                    The command to use. If this option is not specified,
+                    the first executable found in <code class="filename">files/bin</code>
+                    is used.
+                </p></dd><dt><span class="term"><code class="option">--require-version=MAJOR.MINOR.MICRO</code></span></dt><dd><p>
+                    Require this version of later of flatpak to install/update to this build.
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This updates
+                    the [Context] group in the metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This updates
+                    the [Context] group in the metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well known socket to the application. This updates
+                    the [Context] group in the metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well known socket to the application. This updates
+                    the [Context] group in the metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This updates
+                    the [Context] group in the metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This updates
+                    the [Context] group in the metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                 </p><p>
+                    The <code class="code">devel</code> feature allows the application to
+                    access certain syscalls such as <code class="code">ptrace()</code>, and
+                <code class="code">perf_event_open()</code>.
+                </p><p>
+                    The <code class="code">multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code class="code">x86_64</code>
+                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
+                    well.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This updates the [Context] group in the metadata.
+                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
+                    path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This updates the [Environment] group in the metadata.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+
+                    This updates the [Session Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This updates the [Session Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This updates the [System Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This updates the [System Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This updates the [Context] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--runtime=RUNTIME</code>, </span><span class="term"><code class="option">--sdk=SDK</code></span></dt><dd><p>
+                  Change the runtime or sdk used by the app to the specified partial ref. Unspecified parts
+                  of the ref are taken from the old values or defaults.
+                </p></dd><dt><span class="term"><code class="option">--metadata=GROUP=KEY[=VALUE]</code></span></dt><dd><p>
+                  Set a generic key in the metadata file. If value is left out it will
+                  be set to "true".
+                </p></dd><dt><span class="term"><code class="option">--extension=NAME=VARIABLE[=VALUE]</code></span></dt><dd><p>
+                  Add extension point info.
+                </p></dd><dt><span class="term"><code class="option">--extra-data=NAME:SHA256:DOWNLOAD-SIZE:INSTALL-SIZE:URL</code></span></dt><dd><p>
+                    Adds information about extra data uris to the app. These will be downloaded
+                    and verified by the client when the app is installed and placed in the
+                    /app/extra directory. You can also supply an /app/bin/apply_extra script
+                    that will be run after the files are downloaded.
+                </p></dd><dt><span class="term"><code class="option">--no-exports</code></span></dt><dd><p>
+                    Don't look for exports in the build.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537876833760"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-finish /build/my-app --socket=x11 --share=ipc</strong></span>
+        </p><pre class="programlisting">
+Exporting share/applications/gnome-calculator.desktop
+Exporting share/dbus-1/services/org.gnome.Calculator.SearchProvider.service
+More than one executable
+Using gcalccmd as command
+Please review the exported files and the metadata
+</pre></div><div class="refsect1"><a id="idm140537876830784"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-export — Create a repository from a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-export</code>  [OPTION...]  LOCATION   DIRECTORY  [BRANCH]</p></div></div><div class="refsect1"><a id="idm140537878815872"></a><h2>Description</h2><p>
+            Creates or updates a repository with an application build.
+             LOCATION  is the location of the
+            repository.   DIRECTORY  must be a
+            finalized build directory. If   BRANCH 
+            is not specified, it is assumed to be "master".
+        </p><p>
+            If  LOCATION  exists, it is assumed to
+            be an OSTree repository, otherwise a new OSTree repository is
+            created at this location. The repository can be inspected with
+            the <span class="command"><strong>ostree</strong></span> tool.
+        </p><p>
+            The contents of  DIRECTORY  are committed
+            on the branch with name <code class="literal">app/APPNAME/ARCH/BRANCH</code>,
+            where ARCH is the architecture of the runtime that the application
+            is using. A commit filter is used to enforce that only the contents
+            of the <code class="filename">files/</code> and <code class="filename">export/</code>
+            subdirectories and the <code class="filename">metadata</code> file are included
+            in the commit, anything else is ignored.
+        </p><p>
+            The build-update-repo command should be used to update repository
+            metadata whenever application builds are added to a repository.
+        </p></div><div class="refsect1"><a id="idm140537881998096"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
+                    One line subject for the commit message.
+                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
+                    Full description for the commit message.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Specify the architecture component of the branch to export. Only host compatible architectures can be specified.
+                </p></dd><dt><span class="term"><code class="option">--exclude=PATTERN</code></span></dt><dd><p>
+                    Exclude files matching PATTERN from the commit.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--include=PATTERN</code></span></dt><dd><p>
+                    Don't exclude files matching PATTERN from the commit, even if they match the --export patterns.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--metadata=FILENAME</code></span></dt><dd><p>
+                  Use the specified filename as metadata in the exported app instead of
+                  the default file (called <code class="filename">metadata</code>). This is useful
+                  if you want to commit multiple things from a single build tree, typically
+                  used in combination with --files and --exclude.
+                </p></dd><dt><span class="term"><code class="option">--files=SUBDIR</code></span></dt><dd><p>
+                  Use the files in the specified subdirectory as the file contents, rather
+                  than the regular <code class="filename">files</code> directory.
+                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
+                    Run appstream-builder and to update the appstream branch after build.
+                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
+                    Don't update the summary file after the new commit is added. This means
+                    the repository will not be useful for serving over http until build-repo-update
+                    has been run. This is useful is you want to do multiple repo operations before
+                    finally updating the summary.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Export a runtime instead for an app (this uses the usr subdir as files).
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877518560"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-export ~/repos/gnome-calculator/ ~/build/gnome-calculator/ org.gnome.Calculator</strong></span>
+        </p><pre class="programlisting">
+Commit: 9d0044ea480297114d03aec85c3d7ae3779438f9d2cb69d717fb54237acacb8c
+Metadata Total: 605
+Metadata Written: 5
+Content Total: 1174
+Content Written: 1
+Content Bytes Written: 305
+</pre></div><div class="refsect1"><a id="idm140537877515536"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-sign</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-bundle"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-bundle — Create a single-file bundle from a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-bundle</code>  [OPTION...]  LOCATION   FILENAME   NAME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm140537881991584"></a><h2>Description</h2><p>
+            Creates a single-file named  FILENAME 
+            for the application (or runtime) named   NAME 
+            in the repository at   LOCATION . If
+            a   BRANCH  is specified, this branch of
+            the application is used.
+        </p><p>
+            The format of the bundle file is that of an ostree static delta
+            (against an empty base) with some flatpak specific metadata for
+            the application icons and appdata.
+        </p></div><div class="refsect1"><a id="idm140537882023696"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Export a runtime instead of an application.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The arch to create a bundle for.
+                </p></dd><dt><span class="term"><code class="option">--repo-url=URL</code></span></dt><dd><p>
+                    The URL for the repository from which the
+                    application can be updated. Installing the
+                    bundle will automatically configure a remote
+                    for this URL.
+                </p></dd><dt><span class="term"><code class="option">--runtime-repo=URL</code></span></dt><dd><p>
+                  The URL for a .flatpakrepo file that contains
+                  the information about the repository that supplies
+                  the runtimes required by the app.
+                </p></dd><dt><span class="term"><code class="option">--gpg-keys=FILE</code></span></dt><dd><p>
+                    Add the GPG key from FILE (use - for stdin).
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings.
+                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
+                    Export to an OCI image instead of a Flatpak bundle.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878190896"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-import-bundle</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-import-bundle"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-import-bundle — Import a file bundle into a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-import-bundle</code>  [OPTION...]  LOCATION   FILENAME </p></div></div><div class="refsect1"><a id="idm140537880727936"></a><h2>Description</h2><p>
+            Imports a bundle from a file named  FILENAME 
+            into the repository at   LOCATION .
+        </p><p>
+            The format of the bundle file is that generated by build-bundle.
+        </p></div><div class="refsect1"><a id="idm140537877135056"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ref=REF</code></span></dt><dd><p>
+                    Override the ref specified in the bundle.
+                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
+                    Import an OCI image instead of a Flatpak bundle.
+                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
+                    Run appstream-builder and to update the appstream branch after build.
+                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
+                    Don't update the summary file after the new commit is added. This means
+                    the repository will not be useful for serving over http until build-repo-update
+                    has been run. This is useful is you want to do multiple repo operations before
+                    finally updating the summary.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537876925952"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-bundle</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-update-repo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-update-repo — Create a repository from a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-update-repo</code>  [OPTION...]  LOCATION </p></div></div><div class="refsect1"><a id="idm140537879619408"></a><h2>Description</h2><p>
+            Updates repository metadata for the repository at
+             LOCATION . This command generates
+            an OSTree summary file that lists the contents of the repository.
+            The summary is used by flatpak repo-contents and other commands
+            to display the contents of remote repositories.
+        </p><p>
+            After this command,  LOCATION  can be
+            used as the repository location for flatpak add-repo, either by
+            exporting it over http, or directly with a file: url.
+        </p></div><div class="refsect1"><a id="idm140537881976528"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
+                    A title for the repository, e.g. for display in a UI.
+                    The title is stored in the repository summary.
+                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
+                    A default branch for the repository, mainly for use in a UI.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">--generate-static-deltas</code></span></dt><dd><p>
+                  Generate static deltas for all references. This generates from-empty and
+                  delta static files that allow for faster download.
+                </p></dd><dt><span class="term"><code class="option">--prune</code></span></dt><dd><p>
+                    Remove unreferenced objects in repo.
+                </p></dd><dt><span class="term"><code class="option">--prune-depth</code></span></dt><dd><p>
+                    Only keep at most this number of old versions for any particular ref. Default is -1 which means infinite.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877090832"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-repo-contents</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-sign — Sign an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-sign</code>  [OPTION...]  LOCATION   ID  [BRANCH]</p></div></div><div class="refsect1"><a id="idm140537881826800"></a><h2>Description</h2><p>
+            Signs the commit for a specified application or runtime in
+            a local repository.   LOCATION  is
+            the location of the repository.   ID  is the name of the application, or
+            runtime if --runtime is specified. If   BRANCH  is not specified, it is
+            assumed to be "master".
+        </p><p>
+            Applications can also be signed during build-export, but
+            it is sometimes useful to add additional signatures later.
+        </p></div><div class="refsect1"><a id="idm140537881675616"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Sign a runtime instead of an app.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to use.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537878286176"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-sign --gpg-sign=D8BA6573DDD2418027736F1BC33B315E53C1E9D6 /some/repo org.my.App</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537877069552"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span>,
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-builder"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-builder — Help build application dependencies</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak-builder</code>  [OPTION...]  DIRECTORY   MANIFEST </p></div><div class="cmdsynopsis"><p><code class="command">flatpak-builder</code>   --run  [OPTION...]  DIRECTORY   MANIFEST   COMMAND </p></div><div class="cmdsynopsis"><p><code class="command">flatpak-builder</code>   --show-deps  [OPTION...]  MANIFEST </p></div></div><div class="refsect1"><a id="idm140537879587824"></a><h2>Description</h2><p>
+            <span class="command"><strong>flatpak-builder</strong></span> is a wrapper around the <span class="command"><strong>flatpak build</strong></span> command
+            that automates the building of applications and their dependencies. It is one option you can use
+            to build applications.
+        </p><p>
+            The goal of <span class="command"><strong>flatpak-builder</strong></span> is to push as much knowledge about how to build modules to
+            the individual upstream projects. It does this by assuming that the modules adhere to the Build API specified
+            at https://github.com/cgwalters/build-api. This essentially  means that it follows the <span class="command"><strong>./configure
+            &amp;&amp; make &amp;&amp; make install</strong></span> scheme with an optional autogen script. If the upstream
+            does not adhere to the API you can make it do so by adding patches and extra files.
+        </p><p>
+            An invocation of <span class="command"><strong>flatpak-builder</strong></span> proceeds in these stages, each being specified
+            in detail in json format in   MANIFEST :
+            </p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: bullet; "><li class="listitem" style="list-style-type: disc"><p>Download all sources</p></li><li class="listitem" style="list-style-type: disc"><p>Initialize the application directory with <span class="command"><strong>flatpak build-init</strong></span></p></li><li class="listitem" style="list-style-type: disc"><p>Build and install each module with <span class="command"><strong>flatpak build</strong></span></p></li><li class="listitem" style="list-style-type: disc"><p>Clean up the final build tree by removing unwanted files and e.g. stripping binaries</p></li><li class="listitem" style="list-style-type: disc"><p>Finish the application directory with <span class="command"><strong>flatpak build-finish</strong></span></p></li></ul></div><p>
+
+            After this you will end up with a build of the application in   DIRECTORY , which you can
+            export to a repository with the <span class="command"><strong>flatpak build-export</strong></span> command. If you use the <code class="option">--repo</code>
+            option, flatpack-builder will do the export for you at the end of the build process. When flatpak-builder does the
+            export, it also stores the manifest that was used for the build in /app/manifest.json. The manifest is 'resolved',
+            i.e. git branch names are replaced by the actual commit IDs that were used in the build.
+        </p><p>
+            At each of the above steps flatpak caches the result, and if you build the same file again, it will start
+            at the first step where something changes. For instance the first version controlled source that had
+            new commits added, or the first module where some changes to the  MANIFEST  file caused
+            the build environment to change. This makes flatpak-builder very efficient for incremental builds.
+        </p></div><div class="refsect1"><a id="idm140537877413248"></a><h2>Manifest</h2><p>The manifest file is a json file whose format is described in detail in its own manual page.</p></div><div class="refsect1"><a id="idm140537877411824"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Specify the machine architecture to build for. If no architecture is specified, the host architecture will be automatically detected. Only host compatible architectures can be specified.
+                </p></dd><dt><span class="term"><code class="option">--disable-cache</code></span></dt><dd><p>
+                    Don't look at the existing cache for a previous build, instead always rebuild modules.
+                </p></dd><dt><span class="term"><code class="option">--disable-rofiles-fuse</code></span></dt><dd><p>
+                    Disable the use of rofiles-fuse to optimize the cache use via hardlink checkouts.
+                </p></dd><dt><span class="term"><code class="option">--disable-download</code></span></dt><dd><p>
+                     Don't download any sources. This only works if some version of all sources are downloaded
+                     already. This is useful if you want to guarantee that no network i/o is done. However, the
+                     build will fail if some source is not locally available.
+                </p></dd><dt><span class="term"><code class="option">--disable-updates</code></span></dt><dd><p>
+                  Download missing sources, but don't update local mirrors of version control repos. This is useful
+                  to rebuild things but without updating git or bzr repositories from the remote repository.
+                </p></dd><dt><span class="term"><code class="option">--run</code></span></dt><dd><p>
+                  Run a command in a sandbox based on the build dir. This starts flatpak build, with some extra
+                  arguments to give the same environment as the build, and the same permissions the final app
+                  will have. The command to run must be the last argument passed to
+                  flatpak-builder, after the directory and the manifest.
+                </p></dd><dt><span class="term"><code class="option">--build-shell=MODULENAME</code></span></dt><dd><p>
+                  Extract and prepare the sources for the named module, and then start
+                  a shell in a sandbox identical to the one flatpak-builder would use for buildng the module.
+                  This is useful to debug a module.
+                </p></dd><dt><span class="term"><code class="option">--show-deps</code></span></dt><dd><p>
+                  List all the (local) files that the manifest depends on.
+                </p></dd><dt><span class="term"><code class="option">--download-only</code></span></dt><dd><p>
+                     Exit successfully after downloading the required sources.
+                </p></dd><dt><span class="term"><code class="option">--build-only</code></span></dt><dd><p>
+                     Don't do the cleanup and finish stages, which is useful if you
+                     want to build more things into the app.
+                </p></dd><dt><span class="term"><code class="option">--finish-only</code></span></dt><dd><p>
+                     Only do the cleanup, finish and export stages, picking up
+                     where a --build-only command left off.
+                </p></dd><dt><span class="term"><code class="option">--require-changes</code></span></dt><dd><p>
+                    Do nothing, leaving a non-existent  DIRECTORY  if nothing changes since
+                    last cached build. If this is not specified, the latest version from the cache will be put
+                    into   DIRECTORY .
+                </p></dd><dt><span class="term"><code class="option">--keep-build-dirs</code></span></dt><dd><p>
+                    Don't remove the sources and build after having built and installed each module.
+                    This also creates a symlink to the build directory with a stable name ("build-modulename").
+                </p></dd><dt><span class="term"><code class="option">--ccache</code></span></dt><dd><p>
+                     Enable use of ccache in the build (needs ccache in the sdk)
+                </p></dd><dt><span class="term"><code class="option">--stop-at=MODULENAME</code></span></dt><dd><p>
+                     Stop at the specified module, ignoring it and all the following ones
+                     in both the "download" and "build" phases. This is useful for debugging
+                     and development. For instance, you can build all the dependencies, but
+                     stop at the main application so that you can then do a build from a
+                     pre-existing checkout. Implies --build-only.
+                </p></dd><dt><span class="term"><code class="option">--repo=DIR</code></span></dt><dd><p>
+                    When build is done, run export the result to this repository.
+                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
+                    One line subject for the commit message.
+                    Used when exporting the build results.
+                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
+                    Full description for the commit message.
+                    Used when exporting the build results.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    Used when exporting the build results.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings.
+                    Used when exporting the build results.
+                </p></dd><dt><span class="term"><code class="option">--jobs=JOBS</code></span></dt><dd><p>
+                     Limit the number of parallel jobs during the build.
+                     The default is the number of CPUs on the machine.
+                </p></dd><dt><span class="term"><code class="option">--force-clean</code></span></dt><dd><p>
+                    Erase the previous contents of DIRECTORY if it is
+                    not empty.
+                </p></dd><dt><span class="term"><code class="option">--sandbox</code></span></dt><dd><p>
+                    Disable the possibility to specify build-args that
+                    are passed to flatpak build. This means the build
+                    process can't break out of its sandbox, and is
+                    useful when building less trusted software.
+                </p></dd><dt><span class="term"><code class="option">--allow-missing-runtimes</code></span></dt><dd><p>
+                    Do not immediately fail if the sdk or platform runtimes
+                    are not installed on this system. Attempting to build any
+                    manifest modules will still fail if the sdk is missing, but
+                    may be useful for apps that install files without a sandbox
+                    build.
+                </p></dd><dt><span class="term"><code class="option">--rebuild-on-sdk-change</code></span></dt><dd><p>
+                  Record the exact version of the sdk in the cache, and rebuild everything
+                  if it changes. This is useful if you're building against an API-unstable
+                  runtime, like a nightly build.
+                </p></dd><dt><span class="term"><code class="option">--skip-if-unchanged</code></span></dt><dd><p>
+                  If the json is unchanged since the last build of this filename, then
+                  do nothing, and return exit code 42.
+                </p></dd><dt><span class="term"><code class="option">--from-git=GIT</code></span></dt><dd><p>
+                  Look for the manifest in the given git repository. If this option is
+                  given, MANIFEST is interpreted as a relative path inside the repository.
+                </p></dd><dt><span class="term"><code class="option">--from-git-branch=BRANCH</code></span></dt><dd><p>
+                  The branch to use with --from-git.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877306416"></a><h2>Caching</h2><p>
+            flatpak-builder caches sources and partial build results in
+            the .flatpak-builder subdirectory of the current directory. If you
+            use <code class="option">--keep-build-dirs</code>, build directories for each
+            module are also stored here.
+        </p><p>
+            It is safe to remove the contents of the .flatpak-builder
+            directory. This will force a full build the next time you build.
+        </p></div><div class="refsect1"><a id="idm140537877303904"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak-builder my-app-dir manifest.json</strong></span>
+        </p><p>
+            Example manifest file:
+        </p><pre class="programlisting">
+{
+    "id": "org.test.TestApp",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.2",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "test",
+    "clean": [ "/include", "*.la" ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        },
+        "arch": {
+            "x86_64": {
+                "cflags": "-O3 -g",
+            }
+        }
+    },
+    "modules": [
+        {
+            "name": "pygobject",
+            "config-opts": [ "--disable-introspection" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.xz",
+                    "sha256": "fb8a1d4f665130a125011659bd347c7339c944232163dbb9a34fd0686577adb8"
+                },
+                {
+                    "type": "patch",
+                    "path": "required-pygobject-fix.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "pygobject-extra-file",
+                    "dest-filename": "extra-file"
+                }
+            ]
+        },
+        {
+            "name": "babl",
+            "build-options" : { "cxxflags": "-O2 -g -std=c++11" },
+            "cleanup": [ "/bin" ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/babl"
+                }
+            ]
+        },
+        {
+            "name": "testapp",
+            "sources": [
+                {
+                    "type": "bzr",
+                    "url": "lp:testapp"
+                }
+            ]
+        }
+    ]
+}
+</pre></div><div class="refsect1"><a id="idm140537877299024"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-manifest</span>(5)</span>
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-metadata"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-metadata — Information about an application or runtime</p></div><div class="refsect1"><a id="idm140537879465248"></a><h2>Description</h2><p>
+            Flatpak uses metadata files to describe applications and runtimes.
+            The <code class="filename">metadata</code> file for a deployed application or
+            runtime is placed in the toplevel deploy directory. For example, the
+            metadata for the locally installed application org.gnome.Calculator
+            is in
+            <code class="filename">~/.local/share/flatpak/app/org.gnome.Calculator/current/active/metadata</code>.
+        </p><p>
+            Most aspects of the metadata configuration can be overridden when
+            launching applications, either temporarily via options of the flatpak
+            run command, or permanently with the flatpak override command.
+        </p><p>
+            A metadata file describing the effective configuration is available
+            inside the running sandbox at <code class="filename">/run/user/$UID/flatpak-info</code>.
+        </p></div><div class="refsect1"><a id="idm140537878688592"></a><h2>File format</h2><p>
+            The metadata file is using the same .ini file format that is used for
+            systemd unit files or application .desktop files.
+        </p><div class="refsect2"><a id="idm140537878643664"></a><h3>[Application] or [Runtime]</h3><p>
+                Metadata for applications starts with an [Application] group,
+                metadata for runtimes with a [Runtime] group.
+            </p><p>
+                The following keys can be present in these groups:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">name</code> (string)</span></dt><dd><p>The name of the application or runtime. This key is mandatory.</p></dd><dt><span class="term"><code class="option">runtime</code> (string)</span></dt><dd><p>The fully qualified name of the runtime that is used by the application. This key is mandatory for applications.</p></dd><dt><span class="term"><code class="option">sdk</code> (string)</span></dt><dd><p>The fully qualified name of the sdk that matches the runtime.</p></dd><dt><span class="term"><code class="option">command</code> (string)</span></dt><dd><p>The command to run. Only relevant for applications.</p></dd></dl></div></div><div class="refsect2"><a id="idm140537877563504"></a><h3>[Context]</h3><p>
+                This group determines various system resources that may be shared
+                with the application when it is run in a flatpak sandbox.
+            </p><p>
+                All keys in this group (and the group itself) are optional.
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">shared</code> (list)</span></dt><dd><p>
+                        List of subsystems to share with the host system.
+                        Possible subsystems: network, ipc.
+                    </p></dd><dt><span class="term"><code class="option">sockets</code> (list)</span></dt><dd><p>
+                        List of well-known sockets to make available in the sandbox.
+                        Possible sockets: x11, wayland, pulseaudio, session-bus, system-bus.
+                        When making a socket available, flatpak also sets
+                        well-known environment variables like DISPLAY or
+                        DBUS_SYSTEM_BUS_ADDRESS to let the application
+                        find sockets that are not in a fixed location.
+                    </p></dd><dt><span class="term"><code class="option">devices</code> (list)</span></dt><dd><p>
+                        List of devices to make available in the sandbox.
+                        Possible values: dri, kvm, all.
+                    </p></dd><dt><span class="term"><code class="option">filesystems</code> (list)</span></dt><dd><p>
+                        List of filesystem subsets to make available to the
+                        application. Possible values: home, host, xdg-desktop,
+                        xdg-documents, xdg-download xdg-music, xdg-pictures,
+                        xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                        xdg-config, xdg-cache, xdg-data,
+                        an absolute path, or a homedir-relative path like
+                        ~/dir or paths relative to the xdg dirs, like
+                        xdg-download/subdir. The xdg-* arguments can also
+                        specify a subdirectory, such as xdg-pictures/screenshots.
+                        Each entry can have a suffix of
+                        :ro, :rw or :create to indicate if the path should be shared
+                        read-only, read-write or read-write + create if needed
+                        (default is read-write).
+                    </p></dd><dt><span class="term"><code class="option">persistent</code> (list)</span></dt><dd><p>
+                      List of homedir-relative paths to make available at
+                      the corresponding path in the per-application home directory,
+                      allowing the locations to be used for persistent data when
+                      the application does not have access to the real homedir.
+                      For instance making ".myapp" persistent would make "~/.myapp"
+                      in the sandbox a bind mount to "~/.var/app/org.my.App/.myapp",
+                      thus allowing an unmodified application to save data in
+                      the per-application location.
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm140537877811936"></a><h3>[Session Bus Policy]</h3><p>
+                If the <code class="option">sockets</code> key is not allowing full access
+                to the D-Bus session bus, then flatpak provides filtered access.
+            </p><p>
+                The default policy for the session bus only allows the
+                application to own its own application ID and
+                subnames. For instance if the app is called
+                "org.my.App", it can only own "org.my.App" and
+                "org.my.App.*". Its also only allowed to talk to the
+                bus itself (org.freedesktop.DBus) and the portal APIs
+                APIs (bus names of the form org.freedesktop.portal.*).
+            </p><p>
+                Additionally the app is always allowed to reply to
+                messages sent to it, and emit broadcast signals (but
+                these will not reach other sandboxed apps unless they
+                are allowed to talk to your app.
+            </p><p>
+                If the [Session Bus Policy] group is present, it provides
+                policy for session bus access.
+            </p><p>
+                Each key in this group has the form of a D-Bus bus name or
+                prefix thereof, for example <code class="option">org.gnome.SessionManager</code>
+                or <code class="option">org.freedesktop.portal.*</code>
+            </p><p>
+                The possible values for entry are, in increasing order or
+                access:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">none</code></span></dt><dd><p>
+                        The bus name or names in question is invisible to the application.
+                    </p></dd><dt><span class="term"><code class="option">see</code></span></dt><dd><p>
+                        The bus name or names can be enumerated by the application.
+                    </p></dd><dt><span class="term"><code class="option">talk</code></span></dt><dd><p>
+                        The application can send messages/ and receive replies and signals from the bus name or names.
+                    </p></dd><dt><span class="term"><code class="option">own</code></span></dt><dd><p>
+                        The application can own the bus name or names (as well as all the above).
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm140537876626288"></a><h3>[System Bus Policy]</h3><p>
+                If the <code class="option">sockets</code> key is not allowing full access
+                to the D-Bus system bus, then flatpak does not make the system
+                bus available unless the [System Bus Policy] group is present
+                and provides a policy for filtered access.
+            </p><p>
+                Entries in this group have the same form as for the [Session Bus Policy] group.
+                However, the app has no permissions by default.
+            </p></div><div class="refsect2"><a id="idm140537876623632"></a><h3>[Environment]</h3><p>
+                The [Environment] group specifies environment variables to set
+                when running the application.
+            </p><p>
+                Entries in this group have the form <code class="option">VAR=VALUE</code>
+                where <code class="option">VAR</code> is the name of an environment variable
+                to set.
+            </p></div><div class="refsect2"><a id="idm140537876620880"></a><h3>[Extension NAME]</h3><p>
+                Runtimes and applications can define extensions, which are optional,
+                additional runtimes to be mounted at a specified location inside
+                the sandbox when they are present on the system. Typical uses for
+                extensions include translations for applications, or debuginfo
+                for sdks. The name of the extension is specified as part of the
+                group heading.
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">directory</code> (string)</span></dt><dd><p>
+                        The relative path at which the extension will be mounted in
+                        the sandbox. If the extension is for an application, the
+                        path is relative to <code class="filename">/app</code>, otherwise
+                        it is relative to <code class="filename">/usr</code>. This key
+                        is mandatory.
+                    </p></dd><dt><span class="term"><code class="option">version</code> (string)</span></dt><dd><p>
+                        The branch to use when looking for the extension. If this is
+                        not specified, it defaults to the branch of the application or
+                        runtime that the extension is for.
+                    </p></dd><dt><span class="term"><code class="option">versions</code> (string)</span></dt><dd><p>
+                        The branches to use when looking for the extension. If this is
+                        not specified, it defaults to the branch of the application or
+                        runtime that the extension is for.
+                    </p></dd><dt><span class="term"><code class="option">add-ld-path</code> (string)</span></dt><dd><p>
+                        A path relative to the extension directory that will be appended
+                        to LD_LIBRARY_PATH.
+                    </p></dd><dt><span class="term"><code class="option">merge-dirs</code> (string)</span></dt><dd><p>
+                        A list of relative paths of directories below the extension directory
+                        that will be merged.
+                    </p></dd><dt><span class="term"><code class="option">download-if</code> (string)</span></dt><dd><p>
+                        A condition that must be true for the extension to be auto-downloaded.
+                        The only currently recognized value is active-gl-driver, which is true
+                        if the name of the active GL driver matches the extension basename.
+                    </p></dd><dt><span class="term"><code class="option">enable-if</code> (string)</span></dt><dd><p>
+                        A condition that must be true for the extension to be enabled.
+                        The only currently recognized value is active-gl-driver, which is true
+                        if the name of the active GL driver matches the extension basename.
+                    </p></dd><dt><span class="term"><code class="option">subdirectory-suffix</code> (string)</span></dt><dd><p>
+                        A suffix that gets appended to the directory name. This is very
+                        useful when the extension point naming scheme is "reversed". For example,
+                        an extension point for GTK+ themes would be /usr/share/themes/$NAME/gtk-3.0,
+                        which could be achieved using subdirectory-suffix=gtk-3.0.
+                    </p></dd><dt><span class="term"><code class="option">subdirectories</code> (boolean)</span></dt><dd><p>
+                        If this key is set to true, then flatpak will look for
+                        extensions whose name is a prefix of the extension name, and
+                        mount them at the corresponding name below the subdirectory.
+                    </p></dd><dt><span class="term"><code class="option">no-autodownload</code> (boolean)</span></dt><dd><p>
+                        Whether to automatically download this extension
+                        when updating or installing a 'related' application
+                        or runtime.
+                    </p></dd><dt><span class="term"><code class="option">autodelete</code> (boolean)</span></dt><dd><p>
+                        Whether to automatically delete this extension
+                        when deleting a 'related' application or runtime.
+                    </p></dd></dl></div></div></div><div class="refsect1"><a id="idm140537876594704"></a><h2>Example</h2><pre class="programlisting">
+[Application]
+name=org.gnome.Calculator
+runtime=org.gnome.Platform/x86_64/3.20
+sdk=org.gnome.Sdk/x86_64/3.20
+command=gnome-calculator
+
+[Context]
+shared=network;ipc;
+sockets=x11;wayland;
+filesystems=xdg-run/dconf;~/.config/dconf:ro;
+
+[Session Bus Policy]
+ca.desrt.dconf=talk
+
+[Environment]
+DCONF_USER_CONFIG_DIR=.config/dconf
+
+[Extension org.gnome.Calculator.Locale]
+directory=share/runtime/locale
+subdirectories=true
+
+[Extension org.gnome.Calculator.Debug]
+directory=lib/debug
+</pre></div><div class="refsect1"><a id="idm140537876592624"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-override</span>(1)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-flatpakrepo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-flatpakrepo — Reference to a remote</p></div><div class="refsect1"><a id="idm140537880180496"></a><h2>Description</h2><p>
+            Flatpak uses flatpakrepo files to share information about remotes.
+            The <code class="filename">flatpakrepo</code> file contains enough information
+            to add the remote. Use the <span class="command"><strong>flatpak remote-add --from</strong></span>
+            command to do so.
+        </p><p>
+           The filename extension commonly used for flatpakrepo files is <code class="filename">.flatpakrepo</code>.
+        </p></div><div class="refsect1"><a id="idm140537877586896"></a><h2>File format</h2><p>
+            The flatpakrepo file is using the same .ini file format that is used for
+            systemd unit files or application .desktop files.
+        </p><div class="refsect2"><a id="idm140537878799824"></a><h3>[Flatpak Repo]</h3><p>
+                All the information is contained in the [Flatpak Repo] group.
+            </p><p>
+                The following keys can be present in this group:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Url</code> (string)</span></dt><dd><p>The url for the remote. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Title</code> (string)</span></dt><dd><p>The title of the remote. This should be a user-friendly name that can be displayed e.g. in an app store.</p></dd><dt><span class="term"><code class="option">GPGKey</code> (string)</span></dt><dd><p>The base64-encoded gpg key for the remote.</p></dd><dt><span class="term"><code class="option">DefaultBranch</code> (string)</span></dt><dd><p>The default branch to use for this remote.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm140537880221952"></a><h2>Example</h2><pre class="programlisting">
+[Flatpak Repo]
+Title=GEdit
+Url=http://sdk.gnome.org/repo-apps/
+GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
+</pre></div><div class="refsect1"><a id="idm140537880219552"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-flatpakref</span>(5)</span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-flatpakref"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-flatpakref — Reference to a remote for an application or runtime</p></div><div class="refsect1"><a id="idm140537880874784"></a><h2>Description</h2><p>
+            Flatpak uses flatpakref files to share information about a remote for
+            a single application. The <code class="filename">flatpakref</code> file contains
+            enough information to add the remote and install the application.
+            Use the <span class="command"><strong>flatpak install --from</strong></span> command to do so.
+        </p><p>
+           The filename extension commonly used for flatpakref files is <code class="filename">.flatpakref</code>.
+        </p><p>
+           A flatpakref file can also refer to a remote for a runtime.
+        </p></div><div class="refsect1"><a id="idm140537879461248"></a><h2>File format</h2><p>
+            The flatpakref file is using the same .ini file format that is used for
+            systemd unit files or application .desktop files.
+        </p><div class="refsect2"><a id="idm140537879658752"></a><h3>[Flatpak Ref]</h3><p>
+                All the information is contained in the [Flatpak Ref] group.
+            </p><p>
+                The following keys can be present in this group:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Name</code> (string)</span></dt><dd><p>The fully qualified name of the runtime that is used by the application. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Url</code> (string)</span></dt><dd><p>The url for the remote. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Branch</code> (string)</span></dt><dd><p>The name of the branch from which to install the application or runtime. If this key is not specified, the "master" branch is used.</p></dd><dt><span class="term"><code class="option">Title</code> (string)</span></dt><dd><p>The title of the application or runtime. This should be a user-friendly name that can be displayed e.g. in an app store.</p></dd><dt><span class="term"><code class="option">IsRuntime</code> (boolean)</span></dt><dd><p>Whether this file refers to a runtime. If this key is not specified, the file is assumed to refer to an application.</p></dd><dt><span class="term"><code class="option">GPGKey</code> (string)</span></dt><dd><p>The base64-encoded gpg key for the remote.</p></dd><dt><span class="term"><code class="option">RuntimeRepo</code> (string)</span></dt><dd><p>The url for a .flatpakref file for the runtime.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm140537882118272"></a><h2>Example</h2><pre class="programlisting">
+[Flatpak Ref]
+Title=GEdit
+Name=org.gnome.gedit
+Branch=stable
+Url=http://sdk.gnome.org/repo-apps/
+IsRuntime=False
+GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
+</pre></div><div class="refsect1"><a id="idm140537876886752"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span>
+            <span class="citerefentry"><span class="refentrytitle">flatpak-flatpakrepo</span>(5)</span>,
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-make-current"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-make-current — Make a specific version of an app current</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak make-current</code>  [OPTION...]  APP   BRANCH </p></div></div><div class="refsect1"><a id="idm140537876991568"></a><h2>Description</h2><p>
+            Makes a particular branch of an application current. Only the current branch
+            of an app has its exported files (such as desktop files and icons) made visible
+            to the host.
+        </p><p>
+            When a new branch is installed it will automatically be made current, so this
+            command is often not needed.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm140537881289280"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Update a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Update the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to install for.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm140537877535648"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user make-current org.gnome.GEdit 3.14</strong></span>
+        </p></div><div class="refsect1"><a id="idm140537881543216"></a><h2>See also</h2><p>
+            <span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span>,
+            <span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span>
+        </p></div></div></div></body></html>

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -59,6 +59,8 @@ The flatpak command
 
 Most flatpak commands are performed system-wide by default. To perform a command for the current user only, use the ``--user`` option. This allows runtimes and application bundles to be installed per-user, for instance.
 
+Command reference: <http://flatpak.readthedocs.io/latest/en/_static/flatpak-docs.html>
+
 Identifiers
 -----------
 


### PR DESCRIPTION
This adds flatpak-docs.html to the readthedocs website.
The flatpak-docs.html file is generated in the flatpak
repository, by using make html.